### PR TITLE
Support custom paper sizes

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -60,8 +60,16 @@
   /// The paper size.
   /// -> string
   paper: "a4",
-  height: 0pt,
-  width: 0pt,
+
+  /// The page height.
+  /// Only needed if your paper size isn’t supported by the `paper` parameter.
+  /// -> length
+  page-height: 0pt,
+
+  /// The page width.
+  /// Only needed if your paper size isn’t supported by the `paper` parameter.
+  /// -> length
+  page-width: 0pt,
 
   /// #let mtext = text.with(font: "Reforma 1918", weight: "thin")
   ///

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -60,6 +60,8 @@
   /// The paper size.
   /// -> string
   paper: "a4",
+  height: 0pt,
+  width: 0pt,
 
   /// #let mtext = text.with(font: "Reforma 1918", weight: "thin")
   ///
@@ -98,10 +100,18 @@
 
   body,
 ) = {
-  set page(
-    paper: paper,
-    margin: margin,
-  )
+  if height == 0pt {
+    set page(
+      paper: paper,
+      margin: margin,
+    )
+  } else {
+    set page(
+      height: height,
+      width: width,
+      margin: margin,
+    )
+  }
 
   set text(
     size: font-size,

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -100,18 +100,16 @@
 
   body,
 ) = {
-  if height == 0pt {
-    set page(
-      paper: paper,
-      margin: margin,
-    )
-  } else {
-    set page(
-      height: height,
-      width: width,
-      margin: margin,
-    )
-  }
+  set page(
+    margin: margin,
+    paper: paper,
+  )
+
+  // Override the paper size if custom dimensions are given
+  set page(
+    height: page-height,
+    width: page-width,
+  ) if page-height != 0pt or page-width != 0pt
 
   set text(
     size: font-size,


### PR DESCRIPTION
Since I am creating documents for both worldwide and US audiences, I use a custom paper size:

```
  set page(
    width: 8.5in,
    height: 297mm,
  )
```

I believe the proposed patch will make it possible to combine this with the gridlock package.